### PR TITLE
Updates to Post-method and added support for different api url.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,7 +10,7 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="Bowling" target="8" />
+      <module name="Bowling" target="11" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/Bowling.iml
+++ b/Bowling.iml
@@ -5,7 +5,7 @@
       <map />
     </option>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_11">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/company/Connection/APIConnection.java
+++ b/src/main/java/com/company/Connection/APIConnection.java
@@ -1,0 +1,15 @@
+package com.company.Connection;
+
+public class APIConnection {
+
+    private String ceoBackendApi = "http://localhost:8080/bowling/api/points";
+    private String skatBackendApi = "http://13.74.31.101/api/points";
+
+    public String getCeoBackendApi() {
+        return ceoBackendApi;
+    }
+
+    public String getSkatBackendApi() {
+        return skatBackendApi;
+    }
+}

--- a/src/main/java/com/company/Connection/GETConnection.java
+++ b/src/main/java/com/company/Connection/GETConnection.java
@@ -1,8 +1,6 @@
 package com.company.Connection;
 
-import com.company.JSON.JSONHandler;
 import com.company.ObjectClasses.DataObject;
-import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -15,15 +13,15 @@ import java.net.URL;
  * */
 public class GETConnection {
 
-    private String apiPoint = "http://13.74.31.101/api/points";
     private DataObject dataObj;
     private String stringBufferResponse;
 
     /**Method for Calling the pre-defined API, read the content and return the response
+     * Uses the old HttpURLConnection
      *@return Returns the response as a String */
-    public String getData() throws IOException{
+    public String getData_HttpURLConnection(String apiURL) throws IOException{
         dataObj = new DataObject();
-        URL url = new URL(apiPoint);
+        URL url = new URL(apiURL);
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         con.setRequestMethod("GET");
 

--- a/src/main/java/com/company/Connection/POSTConnection.java
+++ b/src/main/java/com/company/Connection/POSTConnection.java
@@ -1,14 +1,13 @@
 package com.company.Connection;
 
-import com.company.ObjectClasses.POSTObject;
-import org.json.JSONObject;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
+import java.net.http.*;
+import java.time.Duration;
+
+//import static jdk.internal.net.http.HttpRequestImpl.USER_AGENT;
 
 public class POSTConnection {
 
@@ -16,22 +15,25 @@ public class POSTConnection {
 
     /**
      * Method to POST a jsonString to the pre-specified server
+     * Method is based on the HttpURLConnection, which might be deprecated for some backend systems.
+     * Works perfectly with SKAT's backend (), but does NOT work for Ceo's Express js backend
      * @param jsonPOSTString: a jsonResponse string containing a token and the final score results*/
-    public void POST(String jsonPOSTString) throws IOException {
-
-        URL url = new URL ("http://13.74.31.101/api/points");
+    public void Post_HttpURLConnection(String jsonPOSTString, String apiURL) throws IOException {
+        URL url = new URL (apiURL);
 
         HttpURLConnection con = (HttpURLConnection)url.openConnection();
-        con.setRequestMethod("POST");
 
+        con.setRequestMethod("POST");
         con.setRequestProperty("Content-Type", "application/json; utf-8");
         con.setRequestProperty("Accept", "application/json");
-
+        con.setRequestProperty("charset", "utf-8");
         con.setDoOutput(true);
+
 
         try(OutputStream os = con.getOutputStream()){
             byte[] input = jsonPOSTString.getBytes("utf-8");
             os.write(input, 0, input.length);
+            os.flush();
         }
 
         int code = con.getResponseCode();
@@ -45,7 +47,48 @@ public class POSTConnection {
             }
             System.out.println("The following JSON string has been sent: \n" + jsonPOSTString);
             System.out.println(response.toString());
+
+        } catch (Exception e){
+            System.out.println("Something went terrible wrong!");
+            System.out.println(e);
+
         }
+    }
+
+    /**
+     * Setting up the HttpClient for posting data
+     * Note that the HTTP version has been set to 1_1, so that it may work with both Skat and Ceo's backend
+     * */
+    private static final HttpClient httpClient = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    /**
+     * Method to POST a jsonString to the pre-specified server
+     * Method is based on the HttpClient, which supports Http2.
+     * Works perfectly with Ceo's Express js backend, but does not work with SKAT's Backend
+     * @param jsonPOSTString: a jsonResponse string containing a token and the final score results*/
+    public void Post_HttpClient(String jsonPOSTString, String apiURL) throws IOException, InterruptedException {
+
+        // add json header
+        HttpRequest request = HttpRequest.newBuilder()
+                .POST(HttpRequest.BodyPublishers.ofString(jsonPOSTString))
+                .uri(URI.create(apiURL))
+                .setHeader("User-Agent", "Java 11 HttpClient Bot") // add request header
+                .header("Content-Type", "application/json")
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        int code = response.statusCode();
+        setRepsonseCode(code);
+
+        // print status code
+        System.out.println(getRepsonseCode());
+
+        // print response body
+        System.out.println(response.body());
     }
 
     public int getRepsonseCode() {

--- a/src/main/java/com/company/Main.java
+++ b/src/main/java/com/company/Main.java
@@ -1,6 +1,9 @@
 package com.company;
 
 import com.company.CalculationsVerTwo.CalculationsVerTwo;
+import com.company.Connection.APIConnection;
+import com.company.Connection.POSTConnection;
+import com.company.Misc.AppStart;
 import com.company.Misc.GETOperations;
 import com.company.Misc.POSTOperations;
 import com.company.ObjectClasses.DataObject;
@@ -10,36 +13,20 @@ import java.io.IOException;
 
 public class Main {
 
-    public static void main(String[] args) throws IOException {
 
+    public static void main(String[] args) throws IOException, InterruptedException {
 
-        // ------------- GET DATA -------------- //
-        GETOperations getOps = new GETOperations();
+        APIConnection apiConn = new APIConnection();
+        AppStart appStart = new AppStart();
 
-        DataObject dataObj = getOps.getData();
-
-        // ------------- Calculations ------------ //
-
-        CalculationsVerTwo calcV2 = new CalculationsVerTwo();
-
-        calcV2.setDataObj(dataObj);
-
-        System.out.println("Retrieved list of scores: " + dataObj.getListOfFrameScores());
-
-        calcV2.setupGameSize();
-
-        calcV2.runCalculations();
-
-        // ------------- POST Data ------------ //
-
-        POSTOperations postOPS = new POSTOperations();
-
-        String jsonString = postOPS.prepareJSONString_toPost(new POSTObject(dataObj.getToken(), dataObj.getFinalScoreList()));
-
-        postOPS.postToAPI(jsonString);
-
-
+        /*Set apiConn to either:
+        apiConn.getCeoBackendApi()
+        apiConn.getSkatBackendApi()
+         */
+        appStart.ExecuteApp(apiConn.getCeoBackendApi());
     }
+
+
 
 
 

--- a/src/main/java/com/company/Misc/AppStart.java
+++ b/src/main/java/com/company/Misc/AppStart.java
@@ -1,0 +1,45 @@
+package com.company.Misc;
+
+import com.company.CalculationsVerTwo.CalculationsVerTwo;
+import com.company.Connection.APIConnection;
+import com.company.ObjectClasses.DataObject;
+import com.company.ObjectClasses.POSTObject;
+
+import java.io.IOException;
+
+public class AppStart {
+
+
+    /**
+     * Method for Executing and running all the operations of the application, from start ot finish
+     * @param apiURL Requires a String with the api URL*/
+    public void ExecuteApp(String apiURL) throws IOException, InterruptedException {
+        // ------------- GET DATA -------------- //
+        GETOperations getOps = new GETOperations();
+
+        DataObject dataObj = getOps.getData(apiURL);
+
+        // ------------- Calculations ------------ //
+
+        CalculationsVerTwo calcV2 = new CalculationsVerTwo();
+
+        calcV2.setDataObj(dataObj);
+
+        System.out.println("Retrieved list of scores: " + dataObj.getListOfFrameScores());
+
+        calcV2.setupGameSize();
+
+        calcV2.runCalculations();
+
+        // ------------- POST Data ------------ //
+
+        POSTOperations postOPS = new POSTOperations();
+
+        String jsonString = postOPS.prepareJSONString_toPost(new POSTObject(dataObj.getToken(), dataObj.getFinalScoreList()));
+
+        System.out.println(jsonString);
+
+        postOPS.postToAPI_httpclient(jsonString, apiURL);
+    }
+
+}

--- a/src/main/java/com/company/Misc/GETOperations.java
+++ b/src/main/java/com/company/Misc/GETOperations.java
@@ -3,20 +3,16 @@ package com.company.Misc;
 import com.company.Connection.GETConnection;
 import com.company.JSON.JSONHandler;
 import com.company.ObjectClasses.DataObject;
-import com.company.ObjectClasses.ScoreFrameObject;
-
-import java.util.List;
-import com.company.Calculations.Calculations;
-import com.company.JSON.JSONHandler;
-import com.company.ObjectClasses.DataObject;
-import com.company.Connection.GETConnection;
-import com.company.ObjectClasses.ScoreFrameObject;
 
 import java.io.IOException;
 
 public class GETOperations {
 
-    public DataObject getData() throws IOException {
+    /**
+     * Method for getting the data from the given apiURL and returning it as a DataObject
+     * @param apiURL: A String with the url to get the data from
+     * @return Returns a DataObject*/
+    public DataObject getData(String apiURL) throws IOException {
 
         //Instantiate DataObject, that will contain all the incoming data
         DataObject dataObj = new DataObject();
@@ -28,7 +24,7 @@ public class GETOperations {
         JSONHandler jsonHandler = new JSONHandler();
 
         //Call the getData() method in GETConnection-class, and assign the results to a String
-        String responseObject = con.getData();
+        String responseObject = con.getData_HttpURLConnection(apiURL);
 
         //Take the string containing the response from the GET API-call, and convert and assign the results to the DataObject
         dataObj = jsonHandler.convertResponseStringToObject(responseObject, dataObj);

--- a/src/main/java/com/company/Misc/POSTOperations.java
+++ b/src/main/java/com/company/Misc/POSTOperations.java
@@ -1,5 +1,6 @@
 package com.company.Misc;
 
+import com.company.Connection.APIConnection;
 import com.company.Connection.POSTConnection;
 import com.company.ObjectClasses.POSTObject;
 import org.json.JSONObject;
@@ -8,6 +9,12 @@ import java.io.IOException;
 
 public class POSTOperations {
 
+    private APIConnection apiConn;
+
+    /**
+     * Method for preparing the PostObject and return it as a JSON String
+     * @param postObject Requires a POSTObject
+     * @return (json)String*/
     public String prepareJSONString_toPost(POSTObject postObject){
 
         JSONObject jsonObject = new JSONObject();
@@ -17,13 +24,24 @@ public class POSTOperations {
         return jsonObject.toString();
     }
 
-    public void postToAPI(String postObjectJsonString) throws IOException {
+    /**
+     * Method for Posting the provided JSONString to the provided String apiURL
+     * Note that this method is using the old HttpURLConnection method, which is not compatible with CeoBackend, perhaps due to issues with modern backends
+     * @param apiURL Requires a String containing the api url
+     * @param postObjectJsonString Requires a (json)String with the data to be send*/
+    public void postToAPI_httpurlconnection(String postObjectJsonString, String apiURL) throws IOException {
         POSTConnection postCon = new POSTConnection();
+        postCon.Post_HttpURLConnection(postObjectJsonString, apiURL);
+    }
 
-        postCon.POST(postObjectJsonString);
-
-        // To be removed later!
-        //System.out.println("The following JSON string has been sent: \n" + postObjectJsonString);
+    /**
+     * Method for Posting the provided JSONString to the provided String apiURL
+     * Note that this method is using the java 11 HttpClient method, to better be compatible with both SkatBackendApi and CeoBackendApi
+     * @param apiURL Requires a String containing the api url
+     * @param postObjectJsonString Requires a (json)String with the data to be send*/
+    public void postToAPI_httpclient(String postObjectJsonString, String apiURL) throws IOException, InterruptedException {
+        POSTConnection postCon = new POSTConnection();
+        postCon.Post_HttpClient(postObjectJsonString, apiURL);
     }
 
 

--- a/src/test/java/com/company/Connection/GETConnectionTest.java
+++ b/src/test/java/com/company/Connection/GETConnectionTest.java
@@ -9,12 +9,26 @@ import static org.junit.jupiter.api.Assertions.*;
 class GETConnectionTest {
 
     /**
+     * Testing Skat Backend
      * Simple test to show that the GET-method returns a string with content, and is not empty or null
      * */
     @Test
-    void test_getData_get_responseCode() throws IOException {
+    void test_getData_get_responseCode_SkatBackend() throws IOException {
         GETConnection getCon = new GETConnection();
-        String dataString = getCon.getData();
+        APIConnection apiCon = new APIConnection();
+        String dataString = getCon.getData_HttpURLConnection(apiCon.getSkatBackendApi());
+        assertNotNull(dataString);
+    }
+
+    /**
+     * Testing Ceo Backend
+     * Simple test to show that the GET-method returns a string with content, and is not empty or null
+     * */
+    @Test
+    void test_getData_get_responseCode_CeoBackend() throws IOException {
+        GETConnection getCon = new GETConnection();
+        APIConnection apiCon = new APIConnection();
+        String dataString = getCon.getData_HttpURLConnection(apiCon.getCeoBackendApi());
         assertNotNull(dataString);
     }
 }

--- a/src/test/java/com/company/Misc/GETOperationsTest.java
+++ b/src/test/java/com/company/Misc/GETOperationsTest.java
@@ -1,5 +1,6 @@
 package com.company.Misc;
 
+import com.company.Connection.APIConnection;
 import com.company.ObjectClasses.DataObject;
 import org.junit.jupiter.api.Test;
 
@@ -10,12 +11,25 @@ import static org.junit.jupiter.api.Assertions.*;
 class GETOperationsTest {
 
     /**
+     * Testing SkatBackend
      * Simple test to show that the token object found in the dataObject is not null*/
     @Test
-    void test_getData_getToken() throws IOException {
+    void test_getData_getToken_SkatBackend() throws IOException {
         GETOperations getOps = new GETOperations();
+        APIConnection apiCon = new APIConnection();
+        DataObject dataObj = getOps.getData(apiCon.getSkatBackendApi());
 
-        DataObject dataObj = getOps.getData();
+        assertNotNull(dataObj.getToken());
+    }
+
+    /**
+     * Testing CeoBackend
+     * Simple test to show that the token object found in the dataObject is not null*/
+    @Test
+    void test_getData_getToken_CeoBackend() throws IOException {
+        GETOperations getOps = new GETOperations();
+        APIConnection apiCon = new APIConnection();
+        DataObject dataObj = getOps.getData(apiCon.getCeoBackendApi());
 
         assertNotNull(dataObj.getToken());
     }


### PR DESCRIPTION
Due to incompatibility between Ceobackend and the Post-method using HttpURlConnection, I've added a new Post Method that uses the HTTPClient-method, that works with both CeoBackend and SkatBackend.
Please note that the HttpClient is set to Version 1_1

Updated the way the app is run, so to better support running with and changing between different api URL.

With the sucess of the HTTPClient in POST, I should consider doing the same woth for the GET-method.