### PR TITLE
Bug fixing and readme-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
     * **To switch API/URL to be used when running the app, open Main.js and change the method being used from apiConn**
     * **The app, by default, has 2 API/URL**
         * *apiConn.getSkatBackend()*
-        * *apiConn.getCeoBackend()*        
+        * *apiConn.getCeoBackend()*   
+            * *Note: as of 26/6-2020 the apiConn.getCeoBackend() currently only works on localhost. Will be updated with the correct api-path to ceobackend, once it's ready*     
 * The following processes are being shown in the console when the application is run:
     * Displays the scores retrieved from the server to be calculated
     * Displays the calculated results and the token, to be send to the server for verification

--- a/src/main/java/com/company/CalculationsVerTwo/NormalCalculationsVerTwo.java
+++ b/src/main/java/com/company/CalculationsVerTwo/NormalCalculationsVerTwo.java
@@ -64,7 +64,6 @@ public class NormalCalculationsVerTwo {
     public void ifPreviousWasDoubleStrike(ScoreAndPrevScoresObject objList){
 
         if(objList.getThirdLeftScore() != null){
-
             int points_secondLeft_DoubleStrikeBeforeNormal_thirdNotNull = objList.getThirdLeftScore().getPoints() + objList.getCurrentScore().getFirstScoreFramePoint() + bp.getStrikeFullPoints();
             objList.getSecondLeftScore().setPoints(points_secondLeft_DoubleStrikeBeforeNormal_thirdNotNull);
 
@@ -86,7 +85,6 @@ public class NormalCalculationsVerTwo {
             objList.getCurrentScore().setPoints(pointsForNormalAfterDoubleStrike);
 
         }
-
     }
 
     /**

--- a/src/main/java/com/company/CalculationsVerTwo/SpareCalculationsVerTwo.java
+++ b/src/main/java/com/company/CalculationsVerTwo/SpareCalculationsVerTwo.java
@@ -23,8 +23,12 @@ public class SpareCalculationsVerTwo {
             }
 
             if(objList.getFirstLeftScore().getScoreType().toString() == "SPARE"){
-                ifPreviousWasSpare(objList);
-            }
+                if( objList.getSecondLeftScore() != null && objList.getSecondLeftScore().getScoreType().toString() == "SPARE"){
+                    ifPreviousDoubleSpare(objList);
+                } else {
+                    ifPreviousWasSpare(objList);
+                }
+                }
         }
 
     }
@@ -70,6 +74,16 @@ public class SpareCalculationsVerTwo {
 
         if(objList.getFirstLeftScore() !=  null){
             int pointsForSpareBeforeSpare = objList.getFirstLeftScore().getPoints() + objList.getCurrentScore().getFirstScoreFramePoint() + bp.getSparePoints();
+            objList.getFirstLeftScore().setPoints(pointsForSpareBeforeSpare);
+        }
+
+    }
+
+    /**Method for calculating, if the previous 2 scores was of type SPARE*/
+    public void ifPreviousDoubleSpare(ScoreAndPrevScoresObject objList){
+
+        if(objList.getSecondLeftScore() != null){
+            int pointsForSpareBeforeSpare = objList.getSecondLeftScore().getPoints() + objList.getCurrentScore().getFirstScoreFramePoint() + bp.getSparePoints();
             objList.getFirstLeftScore().setPoints(pointsForSpareBeforeSpare);
         }
 

--- a/src/main/java/com/company/CalculationsVerTwo/StrikeCalculationVerTwo.java
+++ b/src/main/java/com/company/CalculationsVerTwo/StrikeCalculationVerTwo.java
@@ -23,7 +23,7 @@ public class StrikeCalculationVerTwo {
 
     /**Method that checks for bonus point calculations, if the current score and the 2 previous scores all are strikes*/
     public void checkIfTripleStrike(ScoreAndPrevScoresObject objList) {
-
+        System.out.println("Current score: ID "+ objList.getCurrentScore().getFrameID() + " : Points " + objList.getCurrentScore().getPoints());
         if (objList.getThirdLeftScore() != null) {
 
             if (objList.getFirstLeftScore() != null && objList.getFirstLeftScore().getScoreType().toString() == "STRIKE") {
@@ -40,6 +40,7 @@ public class StrikeCalculationVerTwo {
 
                 if (objList.getSecondLeftScore() != null && objList.getSecondLeftScore().getScoreType().toString() == "STRIKE") {
 
+                    System.out.println("Current score: ID "+ objList.getCurrentScore().getFrameID() + " : Points " + objList.getCurrentScore().getPoints());
                     int threeOrBelowScores_firstStrikeInTripleStrike_points = objList.getSecondLeftScore().getPoints() + bp.getTripleStrikePoints();
                     objList.getSecondLeftScore().setPoints(threeOrBelowScores_firstStrikeInTripleStrike_points);
                 }
@@ -77,8 +78,6 @@ public class StrikeCalculationVerTwo {
     public void bonusFrame_doubleStrike(ScoreAndPrevScoresObject objList){
         if(objList.getCurrentScore().getFirstScoreFramePoint() == 10 && objList.getCurrentScore().getSecondScoreFramePoint() == 10 ){
             if(objList.getFirstLeftScore().getScoreType().toString() == "STRIKE"){
-                int tenthFrameScorePoints = objList.getThirdLeftScore().getPoints() + bp.getTripleStrikePoints();
-                objList.getSecondLeftScore().setPoints(tenthFrameScorePoints);
 
                 int tenthBonusFrame_theEleventhFrame_points = objList.getSecondLeftScore().getPoints() + bp.getTripleStrikePoints();
                 objList.getFirstLeftScore().setPoints(tenthBonusFrame_theEleventhFrame_points);

--- a/src/test/java/com/company/CalculationsVerTwo/SpareCalculationsVerTwoTest.java
+++ b/src/test/java/com/company/CalculationsVerTwo/SpareCalculationsVerTwoTest.java
@@ -261,7 +261,7 @@ class SpareCalculationsVerTwoTest {
         assertEquals("[17, 36, 46]",calcTwo.getDataObj().getFinalScoreList().toString());
     }
 
-    /** Larger test of triple spare caulculations */
+    /** Larger test of points with multiple instances of spares */
     @Test
     void spare_checkCoupleScoresAreSpares() {
 
@@ -288,7 +288,7 @@ class SpareCalculationsVerTwoTest {
         assertEquals("[17, 36, 51, 58, 67, 73, 98, 115, 122, 152]",calcTwo.getDataObj().getFinalScoreList().toString());
     }
 
-    /** Larger test of triple spare caulculations */
+    /** Larger test of triple spare caulculations with (almost) all spare points */
     @Test
     void spare_checkAllScoresAreSpares() {
 


### PR DESCRIPTION
Spare-points bug fixing: Fixed a bug that resultet in incorrect calculations for spares, if there were multiple spares in succession in a large game.

Normal-points bug fixing: Fixed a bug that resultet in incorrect calculations for a normal score in the 9th-frame, if the player successfully got 3 strikes in the tenth- and eleventh-bonus frame.

Readme: Minor readme update regarding the apiConn.getCeoBackend()

Test: Added new test for indentifying bugs (Spare- and Normal-points), all test works as intended (with the exception of the GEt-test against the apiConn.getCeoBackend(), but that will be fixed as the backend itself gets updated with the correct implementation) 