### PR TITLE
New bug: Wrong calc if spare after triple strike

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
     * Alternative, right click on the ***Main***-file (should be located *Bowling/src/main/java/com.company/main.java*) and select the "Run Main.main()"
 * Run the application
     * **Important Note: By default, the app will use the API/URL provided by SKAT ( apiConn.getSkatBackendApi() )**
-    * **To switch API/URL to be used when running the app, open Main.js and change the method being used from apiConn**
-    * **The app, by default, has 2 API/URL**
+    * To switch API/URL to be used when running the app, open Main.js and change the method being used from apiConn
+    * The app, by default, has 2 API/URL
         * *apiConn.getSkatBackend()*
         * *apiConn.getCeoBackend()*   
             * *Note: as of 26/6-2020 the apiConn.getCeoBackend() currently only works on localhost. Will be updated with the correct api-path to ceobackend, once it's ready*     

--- a/src/main/java/com/company/Connection/APIConnection.java
+++ b/src/main/java/com/company/Connection/APIConnection.java
@@ -5,10 +5,14 @@ public class APIConnection {
     private String ceoBackendApi = "http://localhost:8080/bowling/api/points";
     private String skatBackendApi = "http://13.74.31.101/api/points";
 
+    /** Method for getting the API URl to the Ceo Backend
+     * @return Returns the API URL as a String*/
     public String getCeoBackendApi() {
         return ceoBackendApi;
     }
 
+    /** Method for getting the API URl to the SKAT Backend
+     * @return Returns the API URL as a String*/
     public String getSkatBackendApi() {
         return skatBackendApi;
     }

--- a/src/test/java/com/company/CalculationsVerTwo/NormalCalculationsVerTwoTest.java
+++ b/src/test/java/com/company/CalculationsVerTwo/NormalCalculationsVerTwoTest.java
@@ -181,4 +181,6 @@ class NormalCalculationsVerTwoTest {
         assertEquals("[8, 33, 52, 61, 64, 72, 97, 116, 125, 130]",calcTwo.getDataObj().getFinalScoreList().toString());
     }
 
+
+
 }

--- a/src/test/java/com/company/CalculationsVerTwo/SpareCalculationsVerTwoTest.java
+++ b/src/test/java/com/company/CalculationsVerTwo/SpareCalculationsVerTwoTest.java
@@ -315,5 +315,32 @@ class SpareCalculationsVerTwoTest {
         assertEquals("[17, 36, 51, 70, 84, 95, 108, 120, 136, 151]",calcTwo.getDataObj().getFinalScoreList().toString());
     }
 
+    /**Check if the SPARE is correctly calculated, if there was a Triple Strike beofre it!*/
+    @Test
+    void ifPreviousWasTripleStrike() {
+
+        DataObject dataObj = new DataObject();
+
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{10,0},0,1, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{10,0},0,2, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{10,0},0,3, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{6,4},0,4, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{2,8},0,5, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{5,5},0,6, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{7,2},0,7, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{1,4},0,8, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{6,2},0,9, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{10,0},0,10, ScoreFrameObject.ScoreType.UNKNOWN));
+        dataObj.getListOfFrameScores().add(new ScoreFrameObject(new int[]{10,10},0,11, ScoreFrameObject.ScoreType.UNKNOWN));
+
+        CalculationsVerTwo calcTwo = new CalculationsVerTwo();
+
+        calcTwo.setDataObj(dataObj);
+
+        calcTwo.runCalculations();
+
+        assertEquals("[30, 56, 76, 88, 103, 120, 129, 134, 142, 172]",calcTwo.getDataObj().getFinalScoreList().toString());
+    }
+
 
 }


### PR DESCRIPTION
Working on fixing a bug, which results in incorrect calculations, if a SPARE is scored after Triple Strike

APIConnection: Added documentation of the different connection methods